### PR TITLE
Update libmav to latest, more bindings

### DIFF
--- a/src/bind_Message.cpp
+++ b/src/bind_Message.cpp
@@ -90,6 +90,14 @@ void bind_Message(py::module m) {
                  py::arg("field_key"), py::arg("value"), py::arg("array_index") = 0)
             .def("__setitem__", &Message::set<const std::string&>,
                  py::arg("field_key"), py::arg("value"), py::arg("array_index") = 0)
+            .def("set_as_float_pack", &Message::setAsFloatPack<int32_t>,
+                    py::arg("field_key"), py::arg("value"), py::arg("array_index") = 0)
+            .def("set_as_float_pack", &Message::setAsFloatPack<uint32_t>,
+                    py::arg("field_key"), py::arg("value"), py::arg("array_index") = 0)
+            .def("get_as_float_unpack", &Message::getAsFloatUnpack<int32_t>,
+                    py::arg("field_key"), py::arg("array_index") = 0)
+            .def("get_as_float_unpack_unsigned", &Message::getAsFloatUnpack<uint32_t>,
+                    py::arg("field_key"), py::arg("array_index") = 0)
             .def("set_from_dict", [](Message &m, const py::dict &d) {
                 setFromDict(m, d);
                 return m;

--- a/src/bind_PhysicalNetwork.cpp
+++ b/src/bind_PhysicalNetwork.cpp
@@ -51,6 +51,7 @@ void bind_PhysicalNetwork(py::module m) {
 
     py::class_<UDPServer, NetworkInterface>(m, "UDPServer")
             .def(py::init<int>(), py::arg("local_port"))
+            .def("join_multicast_group", &UDPServer::joinMulticastGroup)
             .def("close", &UDPServer::close);
 
     py::class_<TCPServer, NetworkInterface>(m, "TCPServer")

--- a/src/bind_utils.cpp
+++ b/src/bind_utils.cpp
@@ -47,4 +47,8 @@ void bind_utils(py::module m) {
             .def("crc16", &CRC::crc16)
             .def("crc8", &CRC::crc8);
 
+    m.def("float_pack", &floatPack<int32_t>);
+    m.def("float_pack", &floatPack<uint32_t>);
+    m.def("float_unpack", &floatUnpack<int32_t>);
+    m.def("float_unpack_unsigned", &floatUnpack<uint32_t>);
 }

--- a/test.py
+++ b/test.py
@@ -100,6 +100,11 @@ class TestMessage(unittest.TestCase):
         self.assertEqual(message['float_arr_field'], [1.0, 2.0, 3.0])
         self.assertEqual(message['int32_arr_field'], [4, 5, 6])
 
+    def testMessageFloatPackUnpack(self):
+        message = self.message_set.create('BIG_MESSAGE')
+        message.set_as_float_pack('float_field', 12)
+        self.assertEqual(message.get_as_float_unpack('float_field'), 12)
+
     def testSetFromDict(self):
         message = self.message_set.create('BIG_MESSAGE')
 


### PR DESCRIPTION
This updates libmav to latest.

This adds bindings for
- Joining multicast groups
- Float pack / unpack

```python
        message = self.message_set.create('BIG_MESSAGE')
        message.set_as_float_pack('float_field', 12)
        value = message.get_as_float_unpack('float_field')
```