### PR TITLE
Update cibuildwheel

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -59,7 +59,7 @@ jobs:
       if: github.event_name == 'release'
       run: echo ${{ github.event.release.tag_name }} > VERSION.txt
 
-    - uses: pypa/cibuildwheel@v2.12.1
+    - uses: pypa/cibuildwheel@v2.17.0
       env:
         CIBW_ARCHS_MACOS: auto universal2
         CIBW_ARCHS_LINUX: auto aarch64

--- a/src/bind_Message.cpp
+++ b/src/bind_Message.cpp
@@ -90,6 +90,14 @@ void bind_Message(py::module m) {
                  py::arg("field_key"), py::arg("value"), py::arg("array_index") = 0)
             .def("__setitem__", &Message::set<const std::string&>,
                  py::arg("field_key"), py::arg("value"), py::arg("array_index") = 0)
+            .def("set_as_float_pack", &Message::setAsFloatPack<int32_t>,
+                    py::arg("field_key"), py::arg("value"), py::arg("array_index") = 0)
+            .def("set_as_float_pack", &Message::setAsFloatPack<uint32_t>,
+                    py::arg("field_key"), py::arg("value"), py::arg("array_index") = 0)
+            .def("get_as_float_unpack", &Message::getAsFloatUnpack<int32_t>,
+                    py::arg("field_key"), py::arg("array_index") = 0)
+            .def("get_as_float_unpack_unsigned", &Message::getAsFloatUnpack<uint32_t>,
+                    py::arg("field_key"), py::arg("array_index") = 0)
             .def("set_from_dict", [](Message &m, const py::dict &d) {
                 setFromDict(m, d);
                 return m;

--- a/src/bind_PhysicalNetwork.cpp
+++ b/src/bind_PhysicalNetwork.cpp
@@ -51,6 +51,7 @@ void bind_PhysicalNetwork(py::module m) {
 
     py::class_<UDPServer, NetworkInterface>(m, "UDPServer")
             .def(py::init<int>(), py::arg("local_port"))
+            .def("join_multicast_group", &UDPServer::joinMulticastGroup)
             .def("close", &UDPServer::close);
 
     py::class_<TCPServer, NetworkInterface>(m, "TCPServer")

--- a/src/bind_utils.cpp
+++ b/src/bind_utils.cpp
@@ -47,4 +47,8 @@ void bind_utils(py::module m) {
             .def("crc16", &CRC::crc16)
             .def("crc8", &CRC::crc8);
 
+    m.def("float_pack", &floatPack<int32_t>);
+    m.def("float_pack", &floatPack<uint32_t>);
+    m.def("float_unpack", &floatUnpack<int32_t>);
+    m.def("float_unpack_unsigned", &floatUnpack<uint32_t>);
 }

--- a/test.py
+++ b/test.py
@@ -100,6 +100,11 @@ class TestMessage(unittest.TestCase):
         self.assertEqual(message['float_arr_field'], [1.0, 2.0, 3.0])
         self.assertEqual(message['int32_arr_field'], [4, 5, 6])
 
+    def testMessageFloatPackUnpack(self):
+        message = self.message_set.create('BIG_MESSAGE')
+        message.set_as_float_pack('float_field', 12)
+        self.assertEqual(message.get_as_float_unpack('float_field'), 12)
+
     def testSetFromDict(self):
         message = self.message_set.create('BIG_MESSAGE')
 


### PR DESCRIPTION
This updates cibuildwheel in gh-actions. This should also build python 3.12 wheels now.