### PR TITLE
add MessageQueue class

### DIFF
--- a/.github/workflows/pip.yml
+++ b/.github/workflows/pip.yml
@@ -14,6 +14,10 @@ jobs:
       matrix:
         platform: [macos-latest, ubuntu-latest] # windows-latest excluded for now
         python-version: ["3.7", "3.11"]
+        exclude:
+          # 3.7 is not available anymore on macos-latest
+          - platform: macos-latest
+            python-version: "3.7"
 
     runs-on: ${{ matrix.platform }}
 

--- a/src/bind_Connection.cpp
+++ b/src/bind_Connection.cpp
@@ -36,6 +36,9 @@
 #include <pybind11/functional.h>
 #include <pybind11/stl.h>
 #include "mav/Connection.h"
+#include <queue>
+#include <mutex>
+#include <optional>
 
 namespace py = pybind11;
 using namespace mav;
@@ -44,10 +47,47 @@ struct _ExpectationWrapper {
     Connection::Expectation expectation;
 };
 
+// Class to queue incoming messages from a Connection to be accessed asynchronously by python
+// (in order to avoid deadlocks)
+class MessageQueue {
+private:
+    std::queue<Message> _messages;
+    std::mutex _lock;
+    std::weak_ptr<Connection> _connection;
+    CallbackHandle _cb_handle;
+public:
+    MessageQueue(std::shared_ptr<Connection>& connection) : _connection(connection) {
+        _cb_handle = connection->addMessageCallback([this](const Message& message) {
+            std::lock_guard lg{_lock};
+            _messages.push(message);
+        });
+    }
+    ~MessageQueue() {
+        auto connection = _connection.lock();
+        if (connection) {
+            connection->removeMessageCallback(_cb_handle);
+        }
+    }
+
+    std::optional<Message> next() {
+        std::lock_guard lg{_lock};
+        if (_messages.empty()) {
+            return std::nullopt;
+        }
+        const Message ret = _messages.front();
+        _messages.pop();
+        return ret;
+    }
+};
+
 
 void bind_Connection(py::module m) {
     py::class_<_ExpectationWrapper>(m, "_ExpectationWrapper")
             .def(py::init<>());
+
+    py::class_<MessageQueue>(m, "MessageQueue")
+            .def(py::init<std::shared_ptr<Connection>&>())
+            .def("next", &MessageQueue::next, py::call_guard<py::gil_scoped_release>());
 
     py::class_<Connection, std::shared_ptr<Connection>>(m, "Connection")
             .def("alive", &Connection::alive)


### PR DESCRIPTION
When using Connection.add_message_callback from python, there's a potential for deadlocks:
- if the message receiving thread receives a message:
  - takes the _message_callback_mtx lock
  - calls back into python which takes the GIL lock
- if the main thread calls Connection.expect (or receive):
  - GIL lock is held
  - takes the _message_callback_mtx lock So both threads take the locks in opposite order, which can result in deadlocks.

To prevent this we could make sure libmav does not hold locks when calling back to python, unlock GIL when calling Connection.expect (and others), or ensure the receive thread does not call back into python. This patch implements the last solution by introducing an (async) message queue. It allows python code to receive and handle messages at well-defined points.