### PR TITLE
ci: update deprecated artifact@v3 references

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Check metadata
       run: pipx run twine check dist/*
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         path: dist/*.tar.gz
 
@@ -71,7 +71,7 @@ jobs:
       shell: bash
 
     - name: Upload wheels
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: wheelhouse/*.whl
 
@@ -87,7 +87,7 @@ jobs:
       with:
         python-version: "3.x"
 
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: artifact
         path: dist


### PR DESCRIPTION
Replaces the deprecated artifact v3 actions with v4, to prevent brownouts and future problems. See Github blog post announcing this here: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/. There was also an email announcement